### PR TITLE
Make RTK Fix the only one to correspond to STATUS_GBAS_FIX

### DIFF
--- a/src/libnmea_navsat_driver/driver.py
+++ b/src/libnmea_navsat_driver/driver.py
@@ -103,19 +103,19 @@ class Ros2NMEADriver(Node):
             # RTK Fix
             4: [
                 self.default_epe_quality4,
-                NavSatStatus.STATUS_GBAS_FIX,
+                NavSatStatus.STATUS_GBAS_FIX,  # Only RTK Fix is assigned the highest status.
                 NavSatFix.COVARIANCE_TYPE_APPROXIMATED
             ],
             # RTK Float
             5: [
                 self.default_epe_quality5,
-                NavSatStatus.STATUS_GBAS_FIX,
+                NavSatStatus.STATUS_SBAS_FIX,
                 NavSatFix.COVARIANCE_TYPE_APPROXIMATED
             ],
             # WAAS
             9: [
                 self.default_epe_quality9,
-                NavSatStatus.STATUS_GBAS_FIX,
+                NavSatStatus.STATUS_SBAS_FIX,
                 NavSatFix.COVARIANCE_TYPE_APPROXIMATED
             ]
         }


### PR DESCRIPTION
### Description
The [NavSatStatus msg ](https://docs.ros.org/en/noetic/api/sensor_msgs/html/msg/NavSatStatus.html) we use for publishing GPS quality only has 4 levels.

```
int8 STATUS_NO_FIX =  -1        # unable to fix position
int8 STATUS_FIX =      0        # unaugmented fix
int8 STATUS_SBAS_FIX = 1        # with satellite-based augmentation
int8 STATUS_GBAS_FIX = 2        # with ground-based augmentation
```

The current version of `nmea_navsat_driver` assigns both RTK Fix and RTK Float to `STATUS_GBAS_FIX` (the highest status level).
But we want our system to only work with RTK  Fix so this PR changes...
- RTK Float to the lower status of `STATUS_SBAS_FIX`
- and only RTK Fix corresponds to `STATUS_GBAS_FIX`.

### How Has This Been Tested?
Will be tested in the field.

<br>
---

- [DeepX PR Guidelines](https://github.com/DeepX-inc/.github/blob/main/pull_request_guidelines.md) - for descriptions and metadata.
- [Google Code Review Guidelines](https://google.github.io/eng-practices/) - for [authors](https://google.github.io/eng-practices/review/developer/) and [reviewers](https://google.github.io/eng-practices/review/reviewer/).
- [Semantic Code Reviews](https://www.m31coding.com/blog/semantic-reviews.html) - Simple and direct comments without drama.
