### PR TITLE
Publish raw nmea sentence from the serial driver node

### DIFF
--- a/src/libnmea_navsat_driver/driver.py
+++ b/src/libnmea_navsat_driver/driver.py
@@ -35,6 +35,7 @@ import math
 import rclpy
 
 from rclpy.node import Node
+from nmea_msgs.msg import Sentence
 from sensor_msgs.msg import NavSatFix, NavSatStatus, TimeReference
 from geometry_msgs.msg import TwistStamped, QuaternionStamped
 from tf_transformations import quaternion_from_euler
@@ -49,6 +50,7 @@ class Ros2NMEADriver(Node):
         self.fix_pub = self.create_publisher(NavSatFix, 'fix', 10)
         self.vel_pub = self.create_publisher(TwistStamped, 'vel', 10)
         self.heading_pub = self.create_publisher(QuaternionStamped, 'heading', 10)
+        self.nmea_pub = self.create_publisher(Sentence, "nmea_sentence", 10)
 
         self.time_ref_source = self.declare_parameter('time_ref_source', 'gps').value
         self.use_RMC = self.declare_parameter('useRMC', False).value
@@ -137,6 +139,12 @@ class Ros2NMEADriver(Node):
             current_time = timestamp
         else:
             current_time = self.get_clock().now().to_msg()
+
+        nmea_sentence_msg = Sentence()
+        nmea_sentence_msg.header.stamp = current_time
+        nmea_sentence_msg.header.frame_id = frame_id
+        nmea_sentence_msg.sentence = nmea_string
+        self.nmea_pub.publish(nmea_sentence_msg)
 
         current_fix = NavSatFix()
         current_fix.header.stamp = current_time

--- a/src/libnmea_navsat_driver/nodes/nmea_serial_driver.py
+++ b/src/libnmea_navsat_driver/nodes/nmea_serial_driver.py
@@ -33,6 +33,7 @@
 import serial
 
 import rclpy
+from nmea_msgs.msg import Sentence
 
 from libnmea_navsat_driver.driver import Ros2NMEADriver
 
@@ -42,6 +43,11 @@ def main(args=None):
 
     driver = Ros2NMEADriver()
     frame_id = driver.get_frame_id()
+
+    nmea_pub = driver.create_publisher(Sentence, "nmea_sentence", 10)
+
+    nmea_sentence_msg = Sentence()
+    nmea_sentence_msg.header.frame_id = frame_id
 
     serial_port = driver.declare_parameter('port', '/dev/ttyUSB0').value
     serial_baud = driver.declare_parameter('baud', 4800).value
@@ -54,8 +60,16 @@ def main(args=None):
                 data = GPS.readline().strip()
                 try:
                     if isinstance(data, bytes):
-                        data = data.decode("utf-8")
-                    driver.add_sentence(data, frame_id)
+                        data = data.decode('ascii')
+
+                    stamp = driver.get_clock().now().to_msg()
+
+                    driver.add_sentence(data, frame_id, timestamp=stamp)
+
+                    nmea_sentence_msg.header.stamp = stamp
+                    nmea_sentence_msg.sentence = data
+                    nmea_pub.publish(nmea_sentence_msg)
+
                 except ValueError as e:
                     driver.get_logger().warn(
                         "Value error, likely due to missing fields in the NMEA message. Error was: %s. "

--- a/src/libnmea_navsat_driver/nodes/nmea_serial_driver.py
+++ b/src/libnmea_navsat_driver/nodes/nmea_serial_driver.py
@@ -33,7 +33,6 @@
 import serial
 
 import rclpy
-from nmea_msgs.msg import Sentence
 
 from libnmea_navsat_driver.driver import Ros2NMEADriver
 
@@ -43,11 +42,6 @@ def main(args=None):
 
     driver = Ros2NMEADriver()
     frame_id = driver.get_frame_id()
-
-    nmea_pub = driver.create_publisher(Sentence, "nmea_sentence", 10)
-
-    nmea_sentence_msg = Sentence()
-    nmea_sentence_msg.header.frame_id = frame_id
 
     serial_port = driver.declare_parameter('port', '/dev/ttyUSB0').value
     serial_baud = driver.declare_parameter('baud', 4800).value
@@ -60,16 +54,8 @@ def main(args=None):
                 data = GPS.readline().strip()
                 try:
                     if isinstance(data, bytes):
-                        data = data.decode('ascii')
-
-                    stamp = driver.get_clock().now().to_msg()
-
-                    driver.add_sentence(data, frame_id, timestamp=stamp)
-
-                    nmea_sentence_msg.header.stamp = stamp
-                    nmea_sentence_msg.sentence = data
-                    nmea_pub.publish(nmea_sentence_msg)
-
+                        data = data.decode("utf-8")
+                    driver.add_sentence(data, frame_id)
                 except ValueError as e:
                     driver.get_logger().warn(
                         "Value error, likely due to missing fields in the NMEA message. Error was: %s. "


### PR DESCRIPTION
<!--
- Please fill the sections below and the PR metadata.
- Make it readable for reviewers and future visitors.
-->

### Description
<!--- Describe your changes in detail -->

task: https://app.clickup.com/t/86etw0m5b

we want to publish raw nmea for debugging purpose in addition to the nav sat fix message that we are already getting

2 options to do this:
1. Add an nmea_msgs/msg/Sentence publisher to the nmea_serial_driver we are using. (this PR)
2. Use a combination of nmea_topic_serial_reader + nmea_topic_driver which are already provided in the package.

**I decided to do option 1 for the following reasons:**
1. 2 nodes for a gps driver ( nmea_topic_serial_reader + nmea_topic_driver) can be **confusing** (some confusing questions: which node is publishing what, who publishes fix, who publishes the sentence, which node is the real driver, which node has to be restarted when things get messed up) and non-standard because a general ros driver node usually reads from hardware and publishes a ROS message





##  Field PC test
1. connect gps to usb port of the jakarta PC
2. task field:docker-up
3.  ros2 run nmea_navsat_driver nmea_serial_driver --ros-args -p port:='/dev/ttyUSB1' -p baud:=9600 (please note the baud rate for ublox, also adjust the usb device accordingly)
4. ros2 topic echo /nmea_sentence


<img width="657" height="830" alt="Screenshot 2025-11-20 at 0 12 12 PM" src="https://github.com/user-attachments/assets/8ce6bd45-1dc4-4864-8dea-63952d22a377" />


![PXL_20251120_031550415](https://github.com/user-attachments/assets/42969dea-1c42-4120-93d5-7704122ad4b4)


![PXL_20251120_031538285](https://github.com/user-attachments/assets/d714541b-d85b-4561-9774-d9dac893f21d)


<br>

---

- [DeepX PR Guidelines](https://github.com/DeepX-inc/.github/blob/main/pull_request_guidelines.md) - for descriptions and metadata.
- [Google Code Review Guidelines](https://google.github.io/eng-practices/) - for [authors](https://google.github.io/eng-practices/review/developer/) and [reviewers](https://google.github.io/eng-practices/review/reviewer/).
- [Semantic Code Reviews](https://www.m31coding.com/blog/semantic-reviews.html) - Simple and direct comments without drama.
