### PR TITLE
Publish HDOP from the serial driver node

### DIFF
--- a/src/libnmea_navsat_driver/driver.py
+++ b/src/libnmea_navsat_driver/driver.py
@@ -35,10 +35,13 @@ import math
 import rclpy
 
 from rclpy.node import Node
-from nmea_msgs.msg import Sentence
-from sensor_msgs.msg import NavSatFix, NavSatStatus, TimeReference
+
 from geometry_msgs.msg import TwistStamped, QuaternionStamped
+from nmea_msgs.msg import Sentence
+from sensor_msgs.msg import NavSatFix, NavSatStatus, TimeReference\
+from std_msgs.msg import Float64
 from tf_transformations import quaternion_from_euler
+
 from libnmea_navsat_driver.checksum_utils import check_nmea_checksum
 from libnmea_navsat_driver import parser
 
@@ -51,6 +54,7 @@ class Ros2NMEADriver(Node):
         self.vel_pub = self.create_publisher(TwistStamped, 'vel', 10)
         self.heading_pub = self.create_publisher(QuaternionStamped, 'heading', 10)
         self.nmea_pub = self.create_publisher(Sentence, "nmea_sentence", 10)
+        self.hdop_pub = self.create_publisher(Float64, 'hdop', 10)
 
         self.time_ref_source = self.declare_parameter('time_ref_source', 'gps').value
         self.use_RMC = self.declare_parameter('useRMC', False).value
@@ -206,6 +210,7 @@ class Ros2NMEADriver(Node):
             current_fix.position_covariance[8] = (2 * hdop * self.alt_std_dev) ** 2  # FIXME
 
             self.fix_pub.publish(current_fix)
+            self.hdop_pub.publish(Float64(data=hdop))
 
             if not (math.isnan(data['utc_time'][0]) or self.use_GNSS_time):
                 current_time_ref.time_ref = rclpy.time.Time(seconds=data['utc_time'][0], nanoseconds=data['utc_time'][1]).to_msg()

--- a/src/libnmea_navsat_driver/driver.py
+++ b/src/libnmea_navsat_driver/driver.py
@@ -38,7 +38,7 @@ from rclpy.node import Node
 
 from geometry_msgs.msg import TwistStamped, QuaternionStamped
 from nmea_msgs.msg import Sentence
-from sensor_msgs.msg import NavSatFix, NavSatStatus, TimeReference\
+from sensor_msgs.msg import NavSatFix, NavSatStatus, TimeReference
 from std_msgs.msg import Float64
 from tf_transformations import quaternion_from_euler
 


### PR DESCRIPTION
<!--
- Please fill the sections below and the PR metadata.
- Make it readable for reviewers and future visitors.
-->

### Description
<!--- Describe your changes in detail -->
Publish raw HDOP values on a separate topic since nmea navsat driver currently multiples the hdop with constants and puts those values in the covariance matrix
```

hdop = data['hdop']
current_fix.position_covariance[0] = (hdop * self.lon_std_dev) ** 2
current_fix.position_covariance[4] = (hdop * self.lat_std_dev) ** 2
current_fix.position_covariance[8] = (2 * hdop * self.alt_std_dev) ** 2  # FIXME
            
  
```

- But we want the raw hdop values for monitoring and possible using it in the state estimation in the future
- The navsat driver already publishes velocity, time reference, fix, heading all on separate topics with the same header stamp
- For this PR, I used a simple std msgs Float, Ideally it would have been perfect to use float message with a header stamp, but I did not want to add a new message with a header just for that purpose
- Additionally, the current consumer of this message, currently just adds the value to the measurement model and the header is not considered

https://github.com/DeepX-inc/prj_jakarta/blob/479858895a0de0666c396c63b44daa14164a4c91/src/swc/control/state_estimator_cpp/src/core.cpp#L183C17-L183C39

https://github.com/DeepX-inc/prj_jakarta/blob/479858895a0de0666c396c63b44daa14164a4c91/src/swc/control/state_estimator_cpp/src/ukf/ukf_handler.cpp#L127


Future work:
Move to a DeepX specific GPS message with the useful fields


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### How Has This Been Tested?

same as instructions in https://github.com/DeepX-inc/nmea_navsat_driver/pull/3
<!--- Help reviewers by providing explanations, code snippets, checklists, etc. -->
<img width="389" height="408" alt="Screenshot 2025-11-20 at 0 12 41 PM" src="https://github.com/user-attachments/assets/a0df85fa-750f-4965-8ecc-9c7fb6073542" />



<img width="411" height="356" alt="Screenshot 2025-11-20 at 0 11 39 PM" src="https://github.com/user-attachments/assets/8e2c418d-3267-4e9e-8e53-0cc17a1ffe7d" />




<br>
---

- [DeepX PR Guidelines](https://github.com/DeepX-inc/.github/blob/main/pull_request_guidelines.md) - for descriptions and metadata.
- [Google Code Review Guidelines](https://google.github.io/eng-practices/) - for [authors](https://google.github.io/eng-practices/review/developer/) and [reviewers](https://google.github.io/eng-practices/review/reviewer/).
- [Semantic Code Reviews](https://www.m31coding.com/blog/semantic-reviews.html) - Simple and direct comments without drama.
